### PR TITLE
Add URL for genesis file for prysm

### DIFF
--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -62,6 +62,15 @@ if [[ "$1" =~ ^(beacon-chain)$ ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
     exec "$@" "--genesis-state=$GENESIS" ${__rapid_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
+  elif [[ "$*" =~ --pulsechain-testnet-v3 ]]; then
+    GENESIS=/var/lib/prysm/genesis.ssz
+    if [ ! -f "$GENESIS" ]; then
+      echo "Fetching genesis file for PulseChain testnet v3"
+      curl -fsSL -o "$GENESIS" https://checkpoint.v3.testnet.pulsechain.com
+    fi
+# Word splitting is desired for the command line parameters
+# shellcheck disable=SC2086
+    exec "$@" "--genesis-state=$GENESIS" ${__rapid_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
   else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086


### PR DESCRIPTION
This URL will be the default one in the menu for entering the checkpoint sync URL for prysm. This is for the Pulsechain Testnet v3 network, hence this code: "elif [[ "$*" =~ --pulsechain-testnet-v3 ]]; then".