### PR TITLE
Made changes relating to staking and validators

### DIFF
--- a/prysm/Dockerfile.binary
+++ b/prysm/Dockerfile.binary
@@ -46,7 +46,7 @@ USER ${USER}
 
 ENTRYPOINT ["beacon-chain"]
 
-FROM registry.gitlab.com/pulsechaincom/prysm-pulse/beacon-chain:${DOCKER_VC_TAG} as vcsource
+FROM registry.gitlab.com/pulsechaincom/prysm-pulse/validator:${DOCKER_VC_TAG} as vcsource
 
 FROM consensus as validator
 

--- a/staking-deposit-cli/Dockerfile
+++ b/staking-deposit-cli/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_TARGET
 RUN mkdir -p /src
 
 WORKDIR /src
-RUN bash -c "git clone https://github.com/ethereum/staking-deposit-cli.git && cd staking-deposit-cli && git config advice.detachedHead false && git fetch --all --tags \
+RUN bash -c "git clone https://gitlab.com/pulsechaincom/staking-deposit-cli.git && cd staking-deposit-cli && git config advice.detachedHead false && git fetch --all --tags \
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:deposit-pr; git checkout deposit-pr; else git checkout ${BUILD_TARGET}; fi"
 
 FROM python:3.10-alpine


### PR DESCRIPTION
I changed the git repo URL of the staking deposit CLI from that of the Ethereum foundation to PulseChain.

I also changed "beacon-chain"  to "validator" in the URL of the validator container. There were build errors when the URL had "beacon-chain" because the validator container was supposed to be used instead of the consensus container.